### PR TITLE
gem install only on ruby 2.0+

### DIFF
--- a/proc_to_ast.gemspec
+++ b/proc_to_ast.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+
+  spec.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
This gem is supported only ruby 2.0+, but we can `gem install` on ruby 1.9.

So I think I should not `gem install` less than ruby 2.0
## example

``` bash
$ ruby -v
ruby 1.9.3p545 (2014-02-24 revision 45159) [x86_64-darwin13.1.0]

$ gem install --local pkg/proc_to_ast-0.0.6.gem
ERROR:  Error installing pkg/proc_to_ast-0.0.6.gem:
    proc_to_ast requires Ruby version >= 2.0.0.
```
