### PR TITLE
Get rid of retry_limit for parsing

### DIFF
--- a/spec/proc_to_ast_spec.rb
+++ b/spec/proc_to_ast_spec.rb
@@ -23,6 +23,32 @@ describe Proc do
         expect(pr.to_ast).to be_a(AST::Node)
       end
 
+      it "long proc" do
+        pr = Proc.new do |b|
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+          p 1
+        end
+
+        expect(pr.to_ast).to be_a(AST::Node)
+      end
+
       it "converts block passing method" do
         def receive_block(&block)
           block.to_ast


### PR DESCRIPTION
Don't see any advantages to have a retry_limit for parsing.
A disadvantage, on the other hand, is 20 lines limit for Proc that
can be parsed.